### PR TITLE
Db user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: postgres:15.0-alpine
     container_name: azure-voting-db
     environment:
+      POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "mypassword"
     ports:
       - "5432:5432"
@@ -13,6 +14,7 @@ services:
     container_name: azure-voting-app
     environment:
       DATABASE_SERVER: "azure-voting-db"
+      DATABASE_USER: "postgres"
       DATABASE_PASSWORD: "mypassword"
       FIRST_VALUE: "Puppies"
       SECOND_VALUE: "Kittens"

--- a/src/database.rs
+++ b/src/database.rs
@@ -10,9 +10,38 @@ pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
 
 pub fn setup() -> Pool<ConnectionManager<PgConnection>> {
     dotenv().ok();
-    let database_password = env::var("DATABASE_PASSWORD").expect("DATABASE_PASSWORD must be set");
-    let database_server = env::var("DATABASE_SERVER").expect("DATABASE_SERVER must be set");
-    let database_url = format!("postgres://postgres:{}@{}",database_password, database_server);
+
+    // first try to get database connection details from environment variables
+    // if that fails, try to get them from a file in /mnt/secrets
+    // if that fails, panic
+    let database_user = match env::var("DATABASE_USER") {
+        Ok(user) => user,
+        Err(_) => {
+            std::fs::read_to_string("/mnt/secrets-store/database-user")
+                .expect("Failed to read database-user from /mnt/secrets-store")
+        }
+    };
+
+    let database_password = match env::var("DATABASE_PASSWORD") {
+        Ok(password) => password,
+        Err(_) => {
+            std::fs::read_to_string("/mnt/secrets-store/database-password")
+                .expect("Failed to read database-password from /mnt/secrets-store")
+        }
+    };
+
+    let database_server = match env::var("DATABASE_SERVER") {
+        Ok(server) => server,
+        Err(_) => {
+            std::fs::read_to_string("/mnt/secrets-store/database-server")
+                .expect("Failed to read database-server from /mnt/secrets-store")
+        }
+    };
+
+    let database_url = format!(
+        "postgres://{}:{}@{}",
+        database_user, database_password, database_server
+    );
 
     info!("Establishing database connection");
     let mut connection: PgConnection;

--- a/src/database.rs
+++ b/src/database.rs
@@ -18,7 +18,7 @@ pub fn setup() -> Pool<ConnectionManager<PgConnection>> {
         Ok(user) => user,
         Err(_) => {
             std::fs::read_to_string("/mnt/secrets-store/database-user")
-                .expect("Failed to read database-user from /mnt/secrets-store")
+                .unwrap_or_else(|_| "postgres".to_string())
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ use std::env::var;
 use std::fmt;
 use std::sync::Mutex;
 
-
 lazy_static! {
     static ref FIRST_VALUE: String = var("FIRST_VALUE").unwrap_or("Dogs".to_string());
     static ref SECOND_VALUE: String = var("SECOND_VALUE").unwrap_or("Cats".to_string());
@@ -48,18 +47,14 @@ impl fmt::Display for VoteValue {
 impl VoteValue {
     fn source_value(input: &str) -> VoteValue {
         if input == *FIRST_VALUE {
-            return VoteValue::FirstValue
-        }
-        else if input == *SECOND_VALUE {
-            return VoteValue::SecondValue
-        }
-        else if input == "Reset" {
-            return VoteValue::Reset
-        }
-        else {
+            return VoteValue::FirstValue;
+        } else if input == *SECOND_VALUE {
+            return VoteValue::SecondValue;
+        } else if input == "Reset" {
+            return VoteValue::Reset;
+        } else {
             panic!("Failed to match the vote type from {}", input);
         };
-           
     }
 }
 
@@ -88,7 +83,7 @@ async fn submit(
 
     info!("Vote is: {}", &form.vote);
     info!("Debug Vote is: {:?}", &form.vote);
-    
+
     let vote = VoteValue::source_value(&form.vote);
 
     match vote {
@@ -166,12 +161,16 @@ async fn main() -> std::io::Result<()> {
 
     // Load up the dog votes
     let first_value_query = votes.filter(vote_value.eq(FIRST_VALUE.clone()));
-    let first_value_result = first_value_query.select(count(vote_value)).first(&mut connection);
+    let first_value_result = first_value_query
+        .select(count(vote_value))
+        .first(&mut connection);
     let first_value_count = first_value_result.unwrap_or(0);
 
     // Load up the cat votes
     let second_value_query = votes.filter(vote_value.eq(SECOND_VALUE.clone()));
-    let second_value_result = second_value_query.select(count(vote_value)).first(&mut connection);
+    let second_value_result = second_value_query
+        .select(count(vote_value))
+        .first(&mut connection);
     let second_value_count = second_value_result.unwrap_or(0);
 
     // Note: web::Data created _outside_ HttpServer::new closure


### PR DESCRIPTION
## Purpose

Adding the ability to read secrets from `/mnt/secrets-store` directory to demonstrate different ways of configuring secrets in Kubernetes deployments

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type

Adding the ability to read secrets from `/mnt/secrets-store` directory. Read from environment variable, then resort to secret store, and if PostgreSQL username is not passed in, use default `postgres` username.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Open this repo in Codespaces
*  Run `cargo run`
*  Verify the application runs and accepts votes

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
cargo run
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->